### PR TITLE
Fix spurious keystrokes on reset. Increase ps2 buffer to 32 for multiple keypresses

### DIFF
--- a/fw/src/main.c
+++ b/fw/src/main.c
@@ -22,9 +22,9 @@ enum {
 #define KF_TRANSIENT	0x0f
 #define KF_STICKY		0xf0
 
+#define RESET_WAIT 1000
+
 static unsigned char led_state;
-static unsigned long ignore_start;
-#define IGNORE_DUR	1500
 
 int main(void)
 {
@@ -67,13 +67,6 @@ int main(void)
 		}
 
 		c = ps2read();
-		if(ignore_start) {
-			if(get_msec() - ignore_start < IGNORE_DUR) {
-				continue;
-			}
-			ignore_start = 0;
-		}
-
 		switch(c) {
 		case 0xe0:	/* extended */
 			keyflags |= KF_EXT;
@@ -132,11 +125,12 @@ int main(void)
 				printf("CTRL - AMIGA - AMIGA!\r\n");
 				amikb_reset();
 
-				/* ignore input for a period of time after performing a reset to avoid
-				 * spurious input
-				 */
 				keyflags = 0;
-				ignore_start = get_msec();
+
+				reset_timer();
+				while(get_msec() < RESET_WAIT) {}
+				ps2clearbuf();
+
 				break;
 			}
 

--- a/fw/src/ps2kbd.c
+++ b/fw/src/ps2kbd.c
@@ -7,7 +7,7 @@
 
 #define TIMEOUT	100
 
-#define BUF_SZ	16
+#define BUF_SZ	32
 #define BUF_IDX_MASK	(BUF_SZ - 1)
 #define NEXT_IDX(x) (((x) + 1) & BUF_IDX_MASK)
 static volatile unsigned char keybuf[BUF_SZ];
@@ -131,6 +131,11 @@ int ps2setled(unsigned char state)
 	if(c != PS2_ACK) return -1;
 
 	return 0;
+}
+
+void ps2clearbuf(){
+	key_rd = key_wr;
+	return;
 }
 
 ISR(INT0_vect)

--- a/fw/src/ps2kbd.h
+++ b/fw/src/ps2kbd.h
@@ -11,6 +11,7 @@ int ps2write(unsigned char c);
 unsigned char ps2read(void);
 int ps2pending(void);
 int ps2wait(unsigned int timeout);
+void ps2clearbuf();
 
 int ps2setled(unsigned char state);
 


### PR DESCRIPTION
I think I've managed to clear it up.

Before when you reset, sometimes you would get a "lost sync" and that's when the held press would go through.

I think what was happening is this:
* reset function is activated
* ctrl+amiga+amiga releases were sent to the amiga while it is in a resetting state
* amiga misses some bits, doesn't send ACK
* resync() called and remaining bits sent to get an ACK
* keycode that was actually sent is a press (with no corresponding release)

I reverted your commit and just added a bit of a delay after a reset, and I also cleared the PS/2 buffer after the wait so you don't get any of the releases from the reset combination.

One more note, I increased BUF_SZ from 16 to 32. With 16 if you press 7 keys at the same time and then release them at the same time, you will miss one of the releases and it will also do the key repeat. With the increased buffer it no longer misses that.